### PR TITLE
Add / after teamsURL for Shibboleth redirect target.

### DIFF
--- a/coin-teams-war/src/main/webapp/WEB-INF/jsp/landingpage.jsp
+++ b/coin-teams-war/src/main/webapp/WEB-INF/jsp/landingpage.jsp
@@ -22,7 +22,7 @@
 <!-- = Content -->
 <div id="Content">
   <spring:message code="jsp.landingpage.Content" htmlEscape="false" />
-  <c:url context="/Shibboleth.sso" value="/Login" var="loginUrl"><c:param name="target" value="${environment.teamsURL}" /></c:url>
+  <c:url context="/Shibboleth.sso" value="/Login" var="loginUrl"><c:param name="target" value="${environment.teamsURL}/" /></c:url>
   <a class="button" id="loginbutton" href="${loginUrl}"><spring:message code="jsp.landingpage.Login" /></a>
   <br>
   <input type="checkbox" onClick="return requestCookie();"/><spring:message code="jsp.landingpage.skip" />

--- a/coin-teams-war/src/main/webapp/WEB-INF/tags/genericpage.tag
+++ b/coin-teams-war/src/main/webapp/WEB-INF/tags/genericpage.tag
@@ -37,7 +37,7 @@
   <c:if test="${view ne 'gadget'}">
     <link rel="stylesheet" href="<c:url value="/css/app.css?v=20131111" />">
   </c:if>
-  <c:url context="/Shibboleth.sso" value="/Login" var="loginUrl"><c:param name="target" value="${environment.teamsURL}" /></c:url>
+  <c:url context="/Shibboleth.sso" value="/Login" var="loginUrl"><c:param name="target" value="${environment.teamsURL}/" /></c:url>
 </head>
 <body>
   <div class="wrapper">


### PR DESCRIPTION
teamsURL is defined without trailing /, so we need to append the
URL path at each use. This is done consistently throughout the
code, except on login. This causes a spurious redirect from
https://teams.example.org/teams -> https://teams.example.org/teams/
after login.
